### PR TITLE
Update SwiftSyntax dependency version range

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
     ),
   ],
   dependencies: [
-    // Depend on the Swift 5.9 release of SwiftSyntax
-    .package(url: "https://github.com/apple/swift-syntax.git", from: "600.0.0")
+    // Depend on the Swift 6.0 release of SwiftSyntax
+    .package(url: "https://github.com/apple/swift-syntax.git", "600.0.0"..<"602.0.0")
   ],
   targets: [
     // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
## Summary
- Updated SwiftSyntax dependency from `from: "600.0.0"` to `"600.0.0"..<"602.0.0"`
- This allows flexibility to use SwiftSyntax versions 600.x.x and 601.x.x
- Also updated the comment to reflect Swift 6.0 instead of Swift 5.9

## Test plan
- [ ] Verify package resolves dependencies correctly
- [ ] Ensure all tests pass with the updated dependency range

🤖 Generated with [Claude Code](https://claude.ai/code)