### PR TITLE
Change organization for swift-syntax depenency from apple to swiftlang

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
   ],
   dependencies: [
     // Depend on the Swift 6.0 release of SwiftSyntax
-    .package(url: "https://github.com/apple/swift-syntax.git", "600.0.0"..<"603.0.0")
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0"..<"603.0.0")
   ],
   targets: [
     // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
Swift team is migrating repositories to a dedicated organization
https://www.swift.org/blog/swiftlang-github/